### PR TITLE
Fix oob get_unchecked, overlapping _nonoverlapping

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,24 @@ jobs:
         with:
           command: test
 
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    env:
+      MIRIFLAGS: -Zmiri-tag-raw-pointers
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: miri
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: test
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest


### PR DESCRIPTION
Nearly all of the fixes here are actually found by the standard library's debug assertions, if you build with `-Zbuild-std` you can turn them on. But for code like this, I think Miri is the more appropriate tool for ensuring that a validity regression doesn't occur, especially because the test cases here are small enough and provide good coverage to deal with the slowdown of a checking interpreter.